### PR TITLE
Add more spacing to #password_generator_toggle

### DIFF
--- a/wp-password-generator.js
+++ b/wp-password-generator.js
@@ -20,7 +20,7 @@ jQuery( function ( $ ) {
       /** Append the 'Show password' link and bind the click event */
       if ( $('#password_generator_toggle').length === 0 ) {
         $('#send_password').prop( 'checked', 'checked' ); // Only do this the first time
-        $('#password_generator').after( '<span id="password_generator_toggle" style="margin-left:.25em;"><a href="#" role="button">' + wpPasswordGenerator.show + '</a></span>' );
+        $('#password_generator').after( '<span id="password_generator_toggle" style="margin-left:.75em;"><a href="#" role="button">' + wpPasswordGenerator.show + '</a></span>' );
         $('#password_generator_toggle').on( 'click', 'a', function() {
           $( this ).fadeOut( 200, function() {
             $('#password_generator_toggle').html( '<kbd style="font-size:1.2em;">' + $('#pass1').val() + '</kbd>' );


### PR DESCRIPTION
Added slightly more left margin to the #password_generator_toggle link.

**Before:**
![add_new_user__inregister__wordpress](https://cloud.githubusercontent.com/assets/1231306/3599360/d704d8de-0ced-11e4-94a8-7c29143f67d6.png)

It's particularly close if the generator button has a focus state:
![add_new_user__inregister__wordpress](https://cloud.githubusercontent.com/assets/1231306/3599369/eef775c8-0ced-11e4-8359-65c3aab35079.png)

**After:**
![add_new_user__inregister__wordpress](https://cloud.githubusercontent.com/assets/1231306/3599355/c1a2b88a-0ced-11e4-8263-b42d54d1abd2.png)
